### PR TITLE
[Refactor/1] 아티클 페이지 static generation 방식 수정

### DIFF
--- a/src/modules/article/actions.ts
+++ b/src/modules/article/actions.ts
@@ -6,6 +6,12 @@ import {
   TUpdateArticlePayload,
 } from "@types";
 import { createAction, createAsyncAction } from "typesafe-actions";
+import { HYDRATE } from "next-redux-wrapper";
+import { TState } from "./reducer";
+
+interface THydrate {
+  article: TState;
+}
 
 export const CREATE_REQUEST = "article/CREATE_REQUEST" as const;
 export const CREATE_SUCCESS = "article/CREATE_SUCCESS" as const;
@@ -28,6 +34,7 @@ export const FAVORITE_FAILURE = "article/FAVORITE_FAILURE" as const;
 export const RESET_STATUS = "article/RESET_STATUS" as const;
 export const SET_ARTICLE = "article/SET_ARTICLE" as const;
 
+export const hydrateStore = createAction(HYDRATE)<THydrate>();
 export const createRequest = createAction(CREATE_REQUEST)<TArticlePayload>();
 export const createSuccess = createAction(CREATE_SUCCESS)<TArticle>();
 export const createFailure = createAction(CREATE_FAILURE)();

--- a/src/modules/article/reducer.ts
+++ b/src/modules/article/reducer.ts
@@ -22,8 +22,9 @@ import {
   SET_ARTICLE,
 } from "./actions";
 import { TArticles, TArticle } from "@types";
+import { HYDRATE } from "next-redux-wrapper";
 
-interface TState {
+export interface TState {
   isInitialRendering: boolean;
   isLoading: boolean;
   isCreated: boolean;
@@ -119,6 +120,9 @@ const article = createReducer<TState>(initialState, {
   },
   [SET_ARTICLE]: (state, action) => {
     return { ...state, article: action.payload };
+  },
+  [HYDRATE]: (state, action) => {
+    return { ...action.payload.article };
   },
 });
 


### PR DESCRIPTION
## 구현 내용
- 기존에 getStaticProps에서 props로 리턴해서 렌더링 하는 방식 대신,
  getStaticProps 내부에서 dispatch를 통해 store를 업데이트하고,
  해당 store를 통해 렌더링하는 방식으로 수정
- CSR과 동일한 일관성 있는 코딩 스타일을 적용하기 위한 리팩토링.